### PR TITLE
fix waffle badge had old board url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [Waffle Board](https://waffle.io/chingu-voyage-turtles-team-5/momentum-clone)  
 
-[![Stories in Ready](https://badge.waffle.io/chingu-voyage-turtles-team-5/chrome-extension-clone.png?label=ready&title=Ready)](https://waffle.io/chingu-voyage-turtles-team-5/chrome-extension-clone?utm_source=badge)
-[![Stories in Progress](https://badge.waffle.io/chingu-voyage-turtles-team-5/chrome-extension-clone.png?label=In%20Progress&title=In%20Progress)](https://waffle.io/chingu-voyage-turtles-team-5/chrome-extension-clone?utm_source=badge)
+[![Stories in Ready](https://badge.waffle.io/chingu-voyage-turtles-team-5/momentum-clone.png?label=ready&title=Ready)](https://waffle.io/chingu-voyage-turtles-team-5/momentum-clone?utm_source=badge)
+[![Stories in Progress](https://badge.waffle.io/chingu-voyage-turtles-team-5/momentum-clone.png?label=In%20Progress&title=In%20Progress)](https://waffle.io/chingu-voyage-turtles-team-5/momentum-clone?utm_source=badge)
 
 ## Setup
 


### PR DESCRIPTION
<!-- Pull Request Template -->

####  Checklist

- [x] Pull request is from a branch (not master)
- [x] Pull request contains only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
<!-- (replace XXXX with an issue no) -->

#### Description
<!-- Description of changes -->
The waffle badges showing on the README have the old waffle board url, so they aren't showing correctly.  
(unsure if the badges are really that helpful for our little project, but fun to experiment with!)