### PR TITLE
fix linting errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,5 +12,9 @@
         "config": "webpack.config.js"
       }
     }
+  },
+  "rules": {
+    "no-use-before-define": ["error", { "functions": false }],
+    "no-mixed-operators": [ "error", { "allowSamePrecedence": true }]
   }
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Set the default behavior for project - line-endings unix LF
+* text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.eot binary
+*.ttf binary
+*.woff binary
+*.woff2 binary

--- a/src/index.js
+++ b/src/index.js
@@ -1,28 +1,27 @@
-import './manifest.json';
-import './index.html';
+import $ from 'jQuery/jquery.min';
+import 'Src/manifest.json';
+import 'Src/index.html';
+import 'Stylesheets/index.css';
+import 'Stylesheets/top-left-search.css';
+import 'Stylesheets/weather-icons.min.css';
 import 'Images/chrome-grey.svg';
 import 'Images/search-grey.svg';
 import 'Images/nine-squares-grey.svg';
 import 'Images/sea-turtle16.png';
 import 'Images/sea-turtle128.png';
-import 'Stylesheets/index.css';
-import 'Stylesheets/top-left-search.css';
-import 'Stylesheets/weather-icons.min.css';
-import $ from "jQuery/jquery.min.js";
-import { dislayCachedWeather, weatherIsCurrent, getLocationAndWeather } from "Components/weather.js";
-import { addClickHandlers } from "Events/clickHandlers.js"
+import { dislayCachedWeather, weatherIsCurrent, getLocationAndWeather } from 'Components/weather';
+import addClickHandlers from 'Events/clickHandlers';
 
-if (localStorage.getItem("userLocationTimestamp") === null) {
-  localStorage.setItem("userLocationTimestamp", "0");
-  localStorage.setItem("weatherTimestamp", "0");
+if (localStorage.getItem('userLocationTimestamp') === null) {
+  localStorage.setItem('userLocationTimestamp', '0');
+  localStorage.setItem('weatherTimestamp', '0');
 }
 
-$(document).ready(function () {
+$(document).ready(() => {
   dislayCachedWeather();
   if (!weatherIsCurrent()) {
-    console.log("weather is not current");
     getLocationAndWeather();
   }
   addClickHandlers();
   setInterval(getLocationAndWeather, 600000);
-})
+});

--- a/src/scripts/components/weather.js
+++ b/src/scripts/components/weather.js
@@ -1,40 +1,38 @@
-import { getCurrentTime, titleCase, getUserLocation } from 'Scripts/utilities.js';
-import $ from "jQuery/jquery.min.js";
+import { getCurrentTime, titleCase, getUserLocation } from 'Scripts/utilities';
+import $ from 'jQuery/jquery.min';
 import weatherIcons from 'Json/icons.json';
 
 function dislayCachedWeather() {
-  if (localStorage.getItem("currentTemp") !== null)
-    addWeatherToPage()
+  if (localStorage.getItem('currentTemp') !== null) { addWeatherToPage(); }
 }
 
 // use stored weather if not older than 10 minutes (600000 ms)
 function weatherIsCurrent() {
-  var currentTime = getCurrentTime();
-  return localStorage.getItem("currentTemp") !== null && currentTime - localStorage.weatherTimestamp < 600000
+  const currentTime = getCurrentTime();
+  return localStorage.getItem('currentTemp') !== null && currentTime - localStorage.weatherTimestamp < 600000;
 }
 
 // promise to get location and then get weather
 function getLocationAndWeather() {
   getUserLocation()
     .then(getWeather)
-    .catch(function () {
-      console.log("error in getting location");
+    .catch(() => {
     });
 }
 
 // get weather using Glitch https proxy server
 function getWeather() {
-  var api = "https://hickory-office.glitch.me/api.weather?";
-  var lat = "lat=" + localStorage.userLat;
-  var lon = "lon=" + localStorage.userLon;
-  var urlString = [api, lat, "&", lon].join("");
+  const api = 'https://hickory-office.glitch.me/api.weather?';
+  const lat = `lat=${localStorage.userLat}`;
+  const lon = `lon=${localStorage.userLon}`;
+  const urlString = [api, lat, '&', lon].join('');
 
   $.ajax({
     url: urlString,
-    jsonp: true
+    jsonp: true,
   })
-    .done(function (result) {
-      if (localStorage.getItem("userCity") === null) {
+    .done((result) => {
+      if (localStorage.getItem('userCity') === null) {
         localStorage.setItem('userCity', result.name);
         localStorage.setItem('userCountry', result.sys.country);
       }
@@ -44,36 +42,35 @@ function getWeather() {
       localStorage.setItem('weatherId', result.weather[0].id);
       localStorage.setItem('weatherIconCode', result.weather[0].icon);
       localStorage.setItem('weatherTimestamp', new Date().getTime());
-      console.log('currentWeather' + " saved to storage");
       addWeatherToPage();
-    })
+    });
 }
 
 // add weather data to page and un-hide main element (hidden to avoid movement while loading)
 function addWeatherToPage() {
-  $("#city").text(localStorage.userCity);
-  $("#temp").text(Math.round(localStorage.currentTemp) + " " + String.fromCharCode(176));
-  $("#temp-scale").text("C");
-  $("#weather-icon").removeClass();
-  $("#weather-icon").addClass(pickIcon(localStorage.weatherId, localStorage.weatherIconCode));
+  $('#city').text(localStorage.userCity);
+  $('#temp').text(`${Math.round(localStorage.currentTemp)} ${String.fromCharCode(176)}`);
+  $('#temp-scale').text('C');
+  $('#weather-icon').removeClass();
+  $('#weather-icon').addClass(pickIcon(localStorage.weatherId, localStorage.weatherIconCode));
   $('#weather-icon').prop('title', titleCase(localStorage.currentWeatherDesc));
-  $("main").show();
+  $('main').show();
 }
 
 // find correct icon based on weather information 
 function pickIcon(weatherCode, iconCode) {
-  var prefix = 'wi wi-';
-  var icon = weatherIcons[weatherCode].icon;
-  if (iconCode.charAt(2).toLowerCase() == 'n') {
-    icon = 'night-alt-' + icon;
+  const prefix = 'wi wi-';
+  let icon = weatherIcons[weatherCode].icon;
+  if (iconCode.charAt(2).toLowerCase() === 'n') {
+    icon = `night-alt-${icon}`;
   } else {
-    icon = 'day-' + icon;
+    icon = `day-${icon}`;
   }
 
-  if (icon == 'night-alt-clear') {
+  if (icon === 'night-alt-clear') {
     icon = 'night-clear';
   }
-  if (icon == 'day-clear') {
+  if (icon === 'day-clear') {
     icon = 'day-sunny';
   }
   return prefix + icon;

--- a/src/scripts/events/clickHandlers.js
+++ b/src/scripts/events/clickHandlers.js
@@ -1,48 +1,46 @@
-import $ from "jQuery/jquery.min.js";
+import $ from 'jQuery/jquery.min';
 
-/*** Add Click Handlers  ***/
-function addClickHandlers() {
+/** * Add Click Handlers  ** */
+export default function addClickHandlers() {
   // Switch to regular Chrome Search page when Chrome Icon in top-left is clicked
-  $("#chrome-tab-link").click(function () {
+  $('#chrome-tab-link').click(() => {
     chrome.tabs.update({ url: 'chrome-search://local-ntp/local-ntp.html' });
   });
   // Switch to Chrome Apps page when Chrome Apps icon in top-left is clicked
-  $("#chrome-apps-link").click(function () {
+  $('#chrome-apps-link').click(() => {
     chrome.tabs.update({ url: 'chrome://apps/' });
   });
   // toggle showing input field when click on search icon
-  $("#chrome-search-link").click(function (event) {
+  $('#chrome-search-link').click((event) => {
     event.preventDefault();
-    $("#chrome-search-input").toggle();
-    $("#chrome-search-input").focus();
+    $('#chrome-search-input').toggle();
+    $('#chrome-search-input').focus();
   });
   // listener to open search page with search term from input when enter key pressed
-  $("#chrome-search-input").keypress(function (e) {
-    if (e.keyCode == 13) {
-      var searchTerm = $("#chrome-search-input").val().split(" ").join("+");
-      $("#chrome-search-input").val("");
-      chrome.tabs.update({ url: 'http://www.google.com/search?q=' + searchTerm });
+  $('#chrome-search-input').keypress((e) => {
+    if (e.keyCode === 13) {
+      const searchTerm = $('#chrome-search-input').val().split(' ').join('+');
+      $('#chrome-search-input').val('');
+      chrome.tabs.update({ url: `http://www.google.com/search?q=${searchTerm}` });
     }
   });
   // Toggle Weather temperature scale when clicked
-  $("#temp-scale").click(function () {
+  $('#temp-scale').click(() => {
     changeTempScale();
   });
 }
 
 // toggle temperature between scales
 function changeTempScale() {
-  var currentTemp = parseInt($("#temp").text());
-  var currentTempUnit = $("#temp-scale").text();
-  var newTempUnit = currentTempUnit == "C" ? "F" : "C";
-  $("#temp-scale").text(newTempUnit);
-  if (newTempUnit == "F") {
-    var tempInFahrenheit = Math.round(currentTemp * 9 / 5 + 32);
-    $("#temp").text(tempInFahrenheit + " " + String.fromCharCode(176));
+  const currentTemp = parseInt($('#temp').text(), 10);
+  const currentTempUnit = $('#temp-scale').text();
+  const newTempUnit = currentTempUnit === 'C' ? 'F' : 'C';
+  $('#temp-scale').text(newTempUnit);
+  if (newTempUnit === 'F') {
+    const tempInFahrenheit = Math.round((currentTemp * 9 / 5) + 32);
+    $('#temp').text(`${tempInFahrenheit} ${String.fromCharCode(176)}`);
   } else {
-    var tempInCelsius = Math.round((currentTemp - 32) * 5 / 9);
-    $("#temp").text(tempInCelsius + " " + String.fromCharCode(176));
+    const tempInCelsius = Math.round((currentTemp - 32) * 5 / 9);
+    $('#temp').text(`${tempInCelsius} ${String.fromCharCode(176)}`);
   }
 }
-
-export { addClickHandlers };

--- a/src/scripts/utilities.js
+++ b/src/scripts/utilities.js
@@ -1,4 +1,4 @@
-import $ from "jQuery/jquery.min.js";
+import $ from 'jQuery/jquery.min';
 
 function getCurrentTime() {
   return new Date().getTime();
@@ -6,23 +6,23 @@ function getCurrentTime() {
 
 // utility function to change string to titlecase
 function titleCase(str) {
-  return str.toLowerCase().split(' ').map(function (word) {
-    return word.replace(word[0], word[0].toUpperCase());
-  }).join(' ');
+  return str.toLowerCase().split(' ').map(word => word.replace(word[0], word[0].toUpperCase())).join(' ');
 }
 
 function getUserLocation() {
-  return $.getJSON("https://ipinfo.io/geo", function (response) { }, "jsonp")
-    .done(function (response) {
-      var latlon = response.loc.split(",");
+  return $.getJSON({
+    url: 'https://ipinfo.io/geo',
+    jsonp: true,
+  })
+    .done((response) => {
+      const latlon = response.loc.split(',');
       localStorage.setItem('userLat', latlon[0]);
       localStorage.setItem('userLon', latlon[1]);
       localStorage.setItem('userCity', response.city);
       localStorage.setItem('userCountry', response.country);
       localStorage.setItem('userLocationTimestamp', new Date().getTime());
-      console.log('userLocation saved to storage');
-    })
-};
+    });
+}
 
 // Need to fix fallback HTML5 if ipinfo fails
 
@@ -32,9 +32,10 @@ function getUserLocation() {
 //       localStorage.setItem('userLat', position.coords.latitude);
 //       localStorage.setItem('userLon', position.coords.longitude);
 //       localStorage.setItem('userLocationTimestamp', new Date().getTime());
-//       localStorage.removeItem('userCity');  // remove old userCity and userCountry from localstorage
-//       localStorage.removeItem('userCountry'); // they will be retrieved using weather api
-//       console.log('userLocation saved to storage');
+//       // remove old userCity and userCountry from localstorage
+//       // they will be retrieved using weather api
+//       localStorage.removeItem('userCity');  
+//       localStorage.removeItem('userCountry');
 //     })
 //   )
 //   if (navigator.geolocation) {
@@ -43,4 +44,4 @@ function getUserLocation() {
 //   }
 // };
 
-export { titleCase, getCurrentTime, getUserLocation }
+export { titleCase, getCurrentTime, getUserLocation };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,7 @@ module.exports = {
       path.join(__dirname, 'node_modules'),
     ],
     alias: {
+      Src: path.resolve(__dirname, './src/'),
       jQuery: path.resolve(__dirname, './node_modules/jquery/dist'),
       Scripts: path.resolve(__dirname, './src/scripts/'),
       Components: path.resolve(__dirname, './src/scripts/components'),


### PR DESCRIPTION
<!-- Pull Request Template -->

####  Checklist

- [x] Pull request is from a branch (not master)
- [x] Pull request contains only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).

#### Description
<!-- Description of changes -->
* adjusted 2 rules for eslint
    * "no-use-before-define": ["error", { "functions": false }]
will allow to define functions below they are called
    * "no-mixed-operators": [ "error", { "allowSamePrecedence": true }]
will allow writing `(currentTemp * 9 / 5) + 32` without causing error due since * and / operators have same precedence
* added gitattributes file, that will prevent changing file endings from LF to CRLF on windows machines, to prevent line-ending errors when running linter.
* many fixes to code including 
    * changing var to const or let 
    * using single quotes for strings
    * missing semi-colons
    * removing .js file extensions
    * using arrow functions where possible
    * use template literals instead of concat strings
    * use type-safe equality operators === 
    * use default export when only one export on file


